### PR TITLE
Filtering and outlier detection

### DIFF
--- a/SMP_to_CSV.py
+++ b/SMP_to_CSV.py
@@ -70,9 +70,8 @@ class SMP(object):
         # snow surface
         if surfType == 'snow':
             # first, smooth the filtered data to reduce noise
+            # TODO: rolling_window is outside the SMP class. Breaks the class if imported on its own
             smoothedForce = rolling_window(self.subset[:,1], sWindow, fun=np.mean, pad=True)
-
-            #smoothedForce = moving_average(self.subset[:,1], sWindow)
             noiseMed = np.median(smoothedForce[sWindow:sWindow * 2]) # using median for now
             # identify the pen-force peaks, toggle show to True to display inline plot
             ind = detect_peaks(smoothedForce, mph=noiseMed * 2, mpd=sWindow, show=False)
@@ -450,8 +449,6 @@ class SMP(object):
         ax.legend()
         plt.show()
         
-        
-    
     def as_dataframe(self, use_raw=False):
         '''
         may be useful at some point in the future.
@@ -477,6 +474,22 @@ class SMP(object):
         csv_header = " SMP Serial: {}\n {}\n {}\n Lat: {}\n Lon: {}\n Total Samples: {}\n Depth (mm),Force (N)"
         np.savetxt(outCsv, self.data, delimiter=',', comments='#', fmt='%.6f',
                    header=csv_header.format(serial, tstamp.strftime("%Y-%m-%d"), tstamp.strftime("%H:%M:%S"), lat, lon, sampleTotal))
+
+    #Robust Z-Score outliers; can be used to detect ice features and or soil
+    #TODO: TESTING!; Use full data record or subset? If subset, check for it
+    def outliers(self, windowMM = 5, threshold=1, pad=False):
+        sWindow = windowMM/self.header['Samples Dist [mm]']
+        sWindow = (np.ceil(sWindow) // 2 * 2 + 1).astype(int)
+        sBins = rolling_window(self.subset[:,1], sWindow, pad=False)
+        medFilter = rolling_window(self.subset[:,1], sWindow, pad=False, fun=np.median)
+        diff = np.sqrt(np.sum((sBins - medFilter.reshape(medFilter.size,1))**2, axis=-1))
+        mAD = np.nanmedian(diff) #Median absolute dev
+        if pad:
+            padSize = np.absolute(diff.size-p.subset[:,1].size)/2
+            diff = np.lib.pad(diff, (padSize,padSize), 'constant', constant_values=np.nan)
+        rZScore = 0.6745 * diff / mAD #Robust Z-Score
+        #This will throw warnings if the pad is applied, equality does not work for NaN
+        return rZScore > np.nanmedian(rZScore) + (threshold*np.nanstd(rZScore))
 
 #Returns moving window bins of size window. Set pad to NaN fill to size of a.
 #Fun accecpts np.median, np.mean, ect...

--- a/SMP_to_CSV.py
+++ b/SMP_to_CSV.py
@@ -1,6 +1,6 @@
 try:
     import os
-    import sys 
+    import sys
     # hacky bandaid
     sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
     import struct
@@ -8,7 +8,7 @@ try:
     import numpy as np
     import pandas as pd
     import matplotlib.pyplot as plt
-    plt.ioff() # stop displaying quicklook plots by default
+    #plt.ioff() # stop displaying quicklook plots by default
     from tools_ext import detect_peaks # reason for hacky bandaid
     from scipy import signal 
 except ImportError as err:
@@ -57,6 +57,23 @@ class SMP(object):
         Give the user the option to replace them with 0s or interpolate from the nearest non-zero values'''
         #TODO: Replace with try catch to bombproof
         #TODO: Check if its a very short run / air shot
+                
+        sWindows =int(np.round(1/p.header['Samples Dist [mm]']))
+        smoothedForce = moving_average(p.data[:,1], sWindows)
+        smoothDiff = np.diff(smoothedForce)
+        smoothDiff = np.insert(smoothDiff, 0, np.nan)
+        perChange = abs(smoothDiff)/smoothedForce
+        
+        plt.plot(p.subset[:,1])
+        temp = signal.detrend(p.subset[:,1])
+        plt.plot(temp)
+        
+        c1 = p.subset[:,1].mean()
+        c2 = p.subset[:,1].var()  # var is population var by default with np
+        A = signal.detrend(p.subset[:,1] - c1)
+        plt.plot(A)
+
+        
         if any(self.data[:,1] < 0):
             zCor = int(input("Negative force values detected. Replace with 0s (1), interpolate (2): "))
             self.subset = self.data.copy()


### PR DESCRIPTION
Starting work on outlier detection and filtering tools
- Added: rolling_window. Most numpy functions can now inherently be applied against the SMP force data. Pick_surface is currently using this inside the SMP class. This will cause the SMP class to break if imported as a standalone. Need to address this in the short term.
- Added: outliers function that uses a rolling window robust z-score to identify outliers based on a standard deviation threshold and median absolute deviation. Currently uses subset but we need to discuss if this should be made generic or not. If not, needs have data type checking inserted.